### PR TITLE
call exit handler on SIGHUP (when -z used)

### DIFF
--- a/src/carp.c
+++ b/src/carp.c
@@ -762,6 +762,7 @@ int docarp(void)
     
     if (shutdown_at_exit != 0) {
         (void) signal(SIGINT, sighandler_exit);
+        (void) signal(SIGHUP, sighandler_exit);
         (void) signal(SIGQUIT, sighandler_exit);
         (void) signal(SIGTERM, sighandler_exit);
     }


### PR DESCRIPTION
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=574452
