### PR TITLE
deinitialize for a poll error

### DIFF
--- a/src/carp.c
+++ b/src/carp.c
@@ -869,6 +869,9 @@ int docarp(void)
         if ((pfds[0].revents & (POLLERR | POLLHUP)) != 0) {
             logfile(LOG_ERR, _("exiting: pfds[0].revents = %d"),
                     pfds[0].revents);
+            if ((sc.sc_state != BACKUP) && (shutdown_at_exit != 0)) {
+                (void) spawn_handler(dev_desc_fd, downscript);
+            }
             break;
         }
         if (gettimeofday(&now, NULL) != 0) {


### PR DESCRIPTION
On Debian, it's possible to configure ucarp from /etc/network/interfaces.
This works fine with the exception that bringing the interface down causes
ucarp to exit due to a POLLERR, and the downscript is not run if -z was
passed.
