### PR TITLE
Remove install-sh

### DIFF
--- a/install-sh
+++ b/install-sh
@@ -1,1 +1,0 @@
-/usr/local/Cellar/automake/1.14.1/share/automake-1.14/install-sh


### PR DESCRIPTION
I think this is was accidentally committed as it is a symlink and the latest script is copied in when you run ```autoreconf -i```
