### PR TITLE
Pidfile support

### DIFF
--- a/src/carp.c
+++ b/src/carp.c
@@ -43,6 +43,8 @@
 #include "spawn.h"
 #include "log.h"
 #include "carp_p.h"
+#include <sys/types.h>
+#include <unistd.h>
 
 #ifdef WITH_DMALLOC
 # include <dmalloc.h>
@@ -808,6 +810,17 @@ int docarp(void)
     }
     strncpy(iface.ifr_name, interface, sizeof iface.ifr_name);
 #endif    
+    if (pidfile != NULL) {
+	pid_t pid = getpid();
+	FILE *_pidfile = fopen(pidfile, "w");
+	if (_pidfile != NULL) {
+	    char *buf = malloc(100 * sizeof (long));
+	    snprintf(buf, 100, "%ld", (long) pid);
+	    fputs(buf, _pidfile);
+	    free(buf);
+	    fclose(_pidfile);
+	}
+    }
     for (;;) {
 #ifdef SIOCGIFFLAGS
         if (ioctl(fd, SIOCGIFFLAGS, &iface) != 0) {

--- a/src/globals.h
+++ b/src/globals.h
@@ -9,6 +9,7 @@
 # define GLOBAL(A, B) extern A
 #endif
 
+GLOBAL0(char *pidfile);
 GLOBAL0(char *interface);
 GLOBAL0(struct in_addr srcip);
 GLOBAL0(struct in_addr mcastip);

--- a/src/ucarp.c
+++ b/src/ucarp.c
@@ -45,6 +45,7 @@ static void usage(void)
         "--nomcast (-M): use broadcast (instead of multicast) advertisements\n"
         "--facility=<facility> (-f): set syslog facility (default=daemon)\n"
         "--xparam=<value> (-x): extra parameter to send to up/down scripts\n"       
+	"--pidfile (-Z): file to write process's pid to\n"
         "\n"
         "Sample usage:\n"
         "\n"
@@ -256,6 +257,13 @@ int main(int argc, char *argv[])
             no_mcast = 1;
             break;
         }
+	case 'Z': {
+	    free(pidfile);
+	    if ((pidfile = strdup(optarg)) == NULL) {
+		die_mem();
+	    }
+	    break;
+	}
         default: {
             usage();
         }

--- a/src/ucarp_p.h
+++ b/src/ucarp_p.h
@@ -4,6 +4,7 @@
 static const char *GETOPT_OPTIONS = "i:s:v:p:Pa:hb:k:x:nu:d:Dr:zf:Bo:SM";
 
 static struct option long_options[] = {
+    { "pidfile", 1, NULL, 'Z' },
     { "interface", 1, NULL, 'i' },
     { "srcip", 1, NULL, 's' },
     { "mcastip", 1, NULL, 'm' },

--- a/src/ucarp_p.h
+++ b/src/ucarp_p.h
@@ -1,7 +1,7 @@
 #ifndef __CARP_P_H__
 #define __CARP_P_H__ 1
 
-static const char *GETOPT_OPTIONS = "i:s:v:p:Pa:hb:k:x:nu:d:Dr:zf:Bo:SM";
+static const char *GETOPT_OPTIONS = "i:s:v:p:Pa:hb:k:x:nu:d:Dr:zf:Bo:SMZ:";
 
 static struct option long_options[] = {
     { "pidfile", 1, NULL, 'Z' },


### PR DESCRIPTION
This pull request would add support for generating a pidfile.
It adds a long option "--pidfile" and a short option "-Z" (because
"p" and "P" were unavailable).

It is left up to the user to handle a pidfile after ucarp has
terminated.

This resolves #15.